### PR TITLE
Lowered minSdkVersion from 15 to 11

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,7 +6,7 @@ android {
 
     defaultConfig {
         applicationId "za.co.riggaroo.helptut.helptutorialexample"
-        minSdkVersion 15
+        minSdkVersion 11
         targetSdkVersion 23
         versionCode 1
         versionName "1.0"

--- a/materialhelptutorial/build.gradle
+++ b/materialhelptutorial/build.gradle
@@ -13,7 +13,7 @@ android {
     buildToolsVersion "23.0.2"
 
     defaultConfig {
-        minSdkVersion 15
+        minSdkVersion 11
         targetSdkVersion 23
         versionCode 5
         versionName version


### PR DESCRIPTION
Using API level 11 is ok regarding to the API calls. Lower than 11 is not possible because of the ActionBar.

There might be an issue because of the use of "android:fontFamily" in the layout xmls. This is only available from API level 16. But this was existing before already. I think it's negligible.

Fixes #5
