### PR TITLE
Check whether skip or done button must be shown initially

### DIFF
--- a/materialhelptutorial/src/main/java/za/co/riggaroo/materialhelptutorial/tutorial/MaterialTutorialPresenter.java
+++ b/materialhelptutorial/src/main/java/za/co/riggaroo/materialhelptutorial/tutorial/MaterialTutorialPresenter.java
@@ -40,6 +40,12 @@ public class MaterialTutorialPresenter implements MaterialTutorialContract.UserA
             fragments.add(helpTutorialImageFragment);
         }
         tutorialView.setViewPagerFragments(fragments);
+
+        if (tutorialItems.size() == 1) {
+            tutorialView.showDoneButton();
+        } else {
+            tutorialView.showSkipButton();
+        }
     }
 
     @Override


### PR DESCRIPTION
This fixes #25, where the done button isn't shown if only one TutorialItem is used.