### PR TITLE
Don't need to show app_name in library.

### DIFF
--- a/materialhelptutorial/src/main/AndroidManifest.xml
+++ b/materialhelptutorial/src/main/AndroidManifest.xml
@@ -2,7 +2,7 @@
     package="za.co.riggaroo.materialhelptutorial"
     >
 
-    <application android:allowBackup="true" android:label="@string/app_name"
+    <application android:allowBackup="true"
         android:supportsRtl="true">
 
     </application>

--- a/materialhelptutorial/src/main/res/values/strings.xml
+++ b/materialhelptutorial/src/main/res/values/strings.xml
@@ -1,5 +1,4 @@
 <resources>
-    <string name="app_name">help tutorial app</string>
     <string name="tutorial_done">DONE</string>
     <string name="tutorial_skip">SKIP</string>
 </resources>


### PR DESCRIPTION
If lib shows app_name it may overwrite the same string of user's.